### PR TITLE
feat: add registry slug option to plugin

### DIFF
--- a/hooks/post-command
+++ b/hooks/post-command
@@ -12,6 +12,7 @@ zstash save \
   --id "${BK_ZSTASH_ID}" \
   --key "$(printf '%s' "$BUILDKITE_PLUGIN_ZSTASH_KEY")" \
   --store "${BK_STORE}" \
+  --registry-slug "${}{BUILDKITE_PLUGIN_ZSTASH_REGISTRY_SLUG}" \
   --fallback-keys "$(printf '%s' "${BUILDKITE_PLUGIN_ZSTASH_FALLBACK_KEYS:-}")" \
   --bucket-url "${BUILDKITE_PLUGIN_ZSTASH_BUCKET_URL}" \
   --paths "${BUILDKITE_PLUGIN_ZSTASH_PATHS}" \

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -12,7 +12,7 @@ zstash save \
   --id "${BK_ZSTASH_ID}" \
   --key "$(printf '%s' "$BUILDKITE_PLUGIN_ZSTASH_KEY")" \
   --store "${BK_STORE}" \
-  --registry-slug "${}{BUILDKITE_PLUGIN_ZSTASH_REGISTRY_SLUG}" \
+  --registry-slug "${}{BUILDKITE_PLUGIN_ZSTASH_REGISTRY}" \
   --fallback-keys "$(printf '%s' "${BUILDKITE_PLUGIN_ZSTASH_FALLBACK_KEYS:-}")" \
   --bucket-url "${BUILDKITE_PLUGIN_ZSTASH_BUCKET_URL}" \
   --paths "${BUILDKITE_PLUGIN_ZSTASH_PATHS}" \

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -10,6 +10,7 @@ zstash restore \
   --id "${BK_ZSTASH_ID}" \
   --key "$(printf '%s' "$BUILDKITE_PLUGIN_ZSTASH_KEY")" \
   --store "${BK_STORE}" \
+  --registry-slug "${}{BUILDKITE_PLUGIN_ZSTASH_REGISTRY_SLUG}" \
   --fallback-keys "$(printf '%s' "${BUILDKITE_PLUGIN_ZSTASH_FALLBACK_KEYS:-}")" \
   --bucket-url "${BUILDKITE_PLUGIN_ZSTASH_BUCKET_URL}" \
   --paths "${BUILDKITE_PLUGIN_ZSTASH_PATHS}" | read cache_result

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -10,7 +10,7 @@ zstash restore \
   --id "${BK_ZSTASH_ID}" \
   --key "$(printf '%s' "$BUILDKITE_PLUGIN_ZSTASH_KEY")" \
   --store "${BK_STORE}" \
-  --registry-slug "${}{BUILDKITE_PLUGIN_ZSTASH_REGISTRY_SLUG}" \
+  --registry-slug "${}{BUILDKITE_PLUGIN_ZSTASH_REGISTRY}" \
   --fallback-keys "$(printf '%s' "${BUILDKITE_PLUGIN_ZSTASH_FALLBACK_KEYS:-}")" \
   --bucket-url "${BUILDKITE_PLUGIN_ZSTASH_BUCKET_URL}" \
   --paths "${BUILDKITE_PLUGIN_ZSTASH_PATHS}" | read cache_result

--- a/plugin.yml
+++ b/plugin.yml
@@ -20,6 +20,9 @@ configuration:
       # in https://github.com/buildkite/zstash/blob/main/internal/commands/restore.go
       enum: ["s3", "nsc"]
       default: "s3"
+    registry-slug:
+      type: string
+      default: "~"
     skip-save:
       type: boolean
   additionalProperties: false

--- a/plugin.yml
+++ b/plugin.yml
@@ -20,7 +20,7 @@ configuration:
       # in https://github.com/buildkite/zstash/blob/main/internal/commands/restore.go
       enum: ["s3", "nsc"]
       default: "s3"
-    registry-slug:
+    registry:
       type: string
       default: "~"
     skip-save:


### PR DESCRIPTION
This enables us to use a specific cache registry, with `~` using the default.

https://linear.app/buildkite/issue/MDC-568/add-registry-flagkey-zstash-plugin-yaml
