### PR TITLE
Remove cache_result

### DIFF
--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -13,6 +13,4 @@ if [ "${zstash_config}" != "" ]; then
   zstash_command+=" --config ${zstash_config}"
 fi
 
-${zstash_command} | read -r cache_result
-
-echo "Cache HIT: ${cache_result}"
+${zstash_command}


### PR DESCRIPTION
We don't need this...and unbound variables are a thing...so yeet.